### PR TITLE
Feature/add notice message struct#9

### DIFF
--- a/src/detections/application.rs
+++ b/src/detections/application.rs
@@ -1,5 +1,6 @@
 extern crate regex;
 
+use crate::detections::print::MessageNotation;
 use crate::models::event;
 use regex::Regex;
 use std::collections::HashMap;
@@ -42,12 +43,20 @@ impl Application {
                     let re = Regex::new(r"^Application: ").unwrap();
                     let command = re.replace_all(application, "");
                     let username = message_split[4];
+                    let stdout = std::io::stdout();
+                    let mut stdout = stdout.lock();
 
-                    println!("Date    : {}", system.time_created.system_time);
-                    println!("Message EMET Block");
-                    println!("Command : {}", command);
-                    println!("Results : {}", text);
-                    println!("Results : {}", username);
+                    MessageNotation::info_noheader(
+                        &mut stdout,
+                        format!("Date    : {}", system.time_created.system_time),
+                    )
+                    .ok();
+                    MessageNotation::info_noheader(&mut stdout, format!("Message EMET Block")).ok();
+                    MessageNotation::info_noheader(&mut stdout, format!("Command : {}", command))
+                        .ok();
+                    MessageNotation::info_noheader(&mut stdout, format!("Results : {}", text)).ok();
+                    MessageNotation::info_noheader(&mut stdout, format!("Results : {}", username))
+                        .ok();
                 }
             }
             None => {

--- a/src/detections/application.rs
+++ b/src/detections/application.rs
@@ -60,7 +60,9 @@ impl Application {
                 }
             }
             None => {
-                println!("Warning: EMET Message field is blank. Install EMET locally to see full details of this alert");
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::warn(&mut stdout, format!("EMET Message field is blank. Install EMET locally to see full details of this alert")).ok();
             }
         }
     }

--- a/src/detections/applocker.rs
+++ b/src/detections/applocker.rs
@@ -1,5 +1,6 @@
 extern crate regex;
 
+use crate::detections::print::MessageNotation;
 use crate::models::event;
 use regex::Regex;
 use std::collections::HashMap;
@@ -31,9 +32,11 @@ impl AppLocker {
         let message = &system.message.as_ref().unwrap_or(&default);
         let command = re.replace_all(&message, "");
 
-        println!("Message Applocker Warning");
-        println!("Command : {}", command);
-        println!("Results : {}", message);
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        MessageNotation::info_noheader(&mut stdout, format!("Message Applocker Warning")).ok();
+        MessageNotation::info_noheader(&mut stdout, format!("Command : {}", command)).ok();
+        MessageNotation::info_noheader(&mut stdout, format!("Results : {}", message)).ok();
     }
 
     fn applocker_log_block(&mut self, event_id: &String, system: &event::System) {
@@ -46,8 +49,11 @@ impl AppLocker {
         let message = &system.message.as_ref().unwrap_or(&default);
         let command = re.replace_all(&message, "");
 
-        println!("Message Applocker Block");
-        println!("Command : {}", command);
-        println!("Results : {}", message);
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+
+        MessageNotation::info_noheader(&mut stdout, format!("Message Applocker Block")).ok();
+        MessageNotation::info_noheader(&mut stdout, format!("Command : {}", command)).ok();
+        MessageNotation::info_noheader(&mut stdout, format!("Results : {}", message)).ok();
     }
 }

--- a/src/detections/common.rs
+++ b/src/detections/common.rs
@@ -1,3 +1,4 @@
+use crate::detections::print::MessageNotation;
 use crate::models::event;
 use std::collections::HashMap;
 
@@ -18,8 +19,14 @@ impl Common {
     }
 
     pub fn disp(&self) {
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
         for (record_id, date) in self.record_id_list.iter() {
-            println!("date:{:?} record-id: {:?}", date, record_id);
+            MessageNotation::info_noheader(
+                &mut stdout,
+                format!("date:{:?} record-id: {:?}", date, record_id),
+            )
+            .ok();
         }
     }
 

--- a/src/detections/configs.rs
+++ b/src/detections/configs.rs
@@ -1,3 +1,4 @@
+use crate::detections::print::MessageNotation;
 use clap::{App, AppSettings, Arg, ArgMatches};
 use std::fs::File;
 use std::io::prelude::*;
@@ -61,7 +62,13 @@ fn read_csv(filename: &str) -> Vec<Vec<String>> {
             }
         }
         Err(err) => {
-            println!("Error : {} not found , {}", filename, err);
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            MessageNotation::alert(
+                &mut stdout,
+                format!("Error : {} not found , {}", filename, err),
+            )
+            .ok();
         }
     }
 

--- a/src/detections/detection.rs
+++ b/src/detections/detection.rs
@@ -5,6 +5,7 @@ use crate::detections::application;
 use crate::detections::applocker;
 use crate::detections::common;
 use crate::detections::powershell;
+use crate::detections::print::MessageNotation;
 use crate::detections::security;
 use crate::detections::sysmon;
 use crate::detections::system;
@@ -67,10 +68,18 @@ impl Detection {
                                 //&other.detection();
                             }
                         }
-                        Err(err) => println!("{}", err),
+                        Err(err) => {
+                            let stdout = std::io::stdout();
+                            let mut stdout = stdout.lock();
+                            MessageNotation::alert(&mut stdout, format!("{}", err)).ok();
+                        }
                     }
                 }
-                Err(e) => eprintln!("{}", e),
+                Err(e) => {
+                    let stdout = std::io::stdout();
+                    let mut stdout = stdout.lock();
+                    MessageNotation::alert(&mut stdout, format!("{}", e)).ok();
+                }
             }
         }
 

--- a/src/detections/mod.rs
+++ b/src/detections/mod.rs
@@ -4,6 +4,7 @@ mod common;
 pub mod configs;
 pub mod detection;
 mod powershell;
+pub mod print;
 mod security;
 mod sysmon;
 mod system;

--- a/src/detections/print.rs
+++ b/src/detections/print.rs
@@ -1,0 +1,35 @@
+use std::io::{self, Write};
+
+pub struct MessageNotation {}
+
+impl MessageNotation {
+    pub fn alert<W: Write>(w: &mut W, contents: String) -> io::Result<()> {
+        writeln!(w, "[ERROR] {}", contents)
+    }
+    pub fn info_noheader<W: Write>(w: &mut W, contents: String) -> io::Result<()> {
+        writeln!(w, "{}", contents)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::detections::print::MessageNotation;
+
+    #[test]
+    fn test_error_message() {
+        let mut buf = Vec::<u8>::new();
+        let input = "test";
+        let result = MessageNotation::alert(&mut buf, format!("{}", input.to_string()));
+        assert!(result.is_ok());
+        assert_eq!(buf, b"[ERROR] test\n");
+    }
+
+    #[test]
+    fn test_info_noheader_message() {
+        let mut buf = Vec::<u8>::new();
+        let input = "info-test";
+        let result = MessageNotation::info_noheader(&mut buf, format!("{}", input.to_string()));
+        assert!(result.is_ok());
+        assert_eq!(buf, b"info-test\n");
+    }
+}

--- a/src/detections/print.rs
+++ b/src/detections/print.rs
@@ -6,6 +6,9 @@ impl MessageNotation {
     pub fn alert<W: Write>(w: &mut W, contents: String) -> io::Result<()> {
         writeln!(w, "[ERROR] {}", contents)
     }
+    pub fn warn<W: Write>(w: &mut W, contents: String) -> io::Result<()> {
+        writeln!(w, "[WARN] {}", contents)
+    }
     pub fn info_noheader<W: Write>(w: &mut W, contents: String) -> io::Result<()> {
         writeln!(w, "{}", contents)
     }
@@ -31,5 +34,13 @@ mod tests {
         let result = MessageNotation::info_noheader(&mut buf, format!("{}", input.to_string()));
         assert!(result.is_ok());
         assert_eq!(buf, b"info-test\n");
+    }
+    #[test]
+    fn test_warn_message() {
+        let mut buf = Vec::<u8>::new();
+        let input = "warn-test";
+        let result = MessageNotation::warn(&mut buf, format!("{}", input.to_string()));
+        assert!(result.is_ok());
+        assert_eq!(buf, b"[WARN] warn-test\n");
     }
 }

--- a/src/detections/security.rs
+++ b/src/detections/security.rs
@@ -1,3 +1,4 @@
+use crate::detections::print::MessageNotation;
 use crate::detections::utils;
 use crate::models::event;
 use std::collections::HashMap;
@@ -110,8 +111,12 @@ impl Security {
     }
 
     fn print_console(v: Vec<String>) -> Option<Vec<String>> {
-        v.iter().for_each(|s| println!("{}", s));
-        println!("\n");
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        v.iter().for_each(|s| {
+            MessageNotation::info_noheader(&mut stdout, format!("{}", s)).ok();
+        });
+        MessageNotation::info_noheader(&mut stdout, format!("\n")).ok();
         return Option::Some(v);
     }
 
@@ -158,12 +163,35 @@ impl Security {
                 // alert_all_adminが有効であれば、標準出力して知らせる
                 // DeepBlueCLIでは必ず0になっていて、基本的には表示されない。
                 if self.alert_all_admin == 1 {
-                    println!("Date:{}", system_time);
-                    println!("Logon with SeDebugPrivilege (admin access)");
-                    println!("Username:{}", event_data["SubjectUserName"]);
-                    println!("Domain:{}", event_data["SubjectDomainName"]);
-                    println!("User SID:{}", event_data["SubjectUserSid"]);
-                    println!("Domain:{}", event_data["PrivilegeList"]);
+                    let stdout = std::io::stdout();
+                    let mut stdout = stdout.lock();
+                    MessageNotation::info_noheader(&mut stdout, format!("Date:{}", system_time))
+                        .ok();
+                    MessageNotation::info_noheader(
+                        &mut stdout,
+                        format!("Logon with SeDebugPrivilege (admin access)"),
+                    )
+                    .ok();
+                    MessageNotation::info_noheader(
+                        &mut stdout,
+                        format!("Username:{}", event_data["SubjectUserName"]),
+                    )
+                    .ok();
+                    MessageNotation::info_noheader(
+                        &mut stdout,
+                        format!("Domain:{}", event_data["SubjectDomainName"]),
+                    )
+                    .ok();
+                    MessageNotation::info_noheader(
+                        &mut stdout,
+                        format!("User SID:{}", event_data["SubjectUserSid"]),
+                    )
+                    .ok();
+                    MessageNotation::info_noheader(
+                        &mut stdout,
+                        format!("Domain:{}", event_data["PrivilegeList"]),
+                    )
+                    .ok();
                 }
 
                 self.total_admin_logons += 1;
@@ -442,6 +470,7 @@ mod tests {
     extern crate quick_xml;
 
     use crate::detections::security;
+    use crate::detections::security::MessageNotation;
     use crate::models::event;
 
     // 正しくヒットするパターン
@@ -450,7 +479,9 @@ mod tests {
         let xml_str = get_account_created_xml();
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 
@@ -489,7 +520,9 @@ mod tests {
             get_account_created_xml().replace("<EventID>4720</EventID>", "<EventID>4721</EventID>");
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 
@@ -529,7 +562,9 @@ mod tests {
         </Event>"#;
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 
@@ -618,7 +653,9 @@ mod tests {
         let xml_str = get_add_member_security_group_xml();
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 
@@ -657,7 +694,9 @@ mod tests {
             .replace(r"<EventID>4732</EventID>", r"<EventID>4728</EventID>");
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 
@@ -696,7 +735,9 @@ mod tests {
             .replace(r"<EventID>4732</EventID>", r"<EventID>4756</EventID>");
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 
@@ -735,7 +776,9 @@ mod tests {
             .replace(r"<EventID>4732</EventID>", r"<EventID>4757</EventID>");
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 
@@ -757,7 +800,9 @@ mod tests {
         );
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 
@@ -798,7 +843,9 @@ mod tests {
         </Event>"#;
         let event: event::Evtx = quick_xml::de::from_str(&xml_str)
             .map_err(|e| {
-                println!("{}", e.to_string());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::alert(&mut stdout, format!("{}", e.to_string())).ok();
             })
             .unwrap();
 

--- a/src/detections/sysmon.rs
+++ b/src/detections/sysmon.rs
@@ -1,3 +1,4 @@
+use crate::detections::print::MessageNotation;
 use crate::detections::utils::check_command;
 use crate::models::event;
 use std::collections::HashMap;
@@ -55,11 +56,21 @@ impl Sysmon {
             if _signed == "false" {
                 let _image = event_data.get("Image").unwrap_or(&default);
                 let _command_line = event_data.get("ImageLoaded").unwrap_or(&default);
-
-                println!("Date : {}", system_time);
-                println!("Message : Unsigned Image (DLL)");
-                println!("Result  : Loaded by: {}", _image);
-                println!("Command : {}", _command_line);
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::info_noheader(&mut stdout, format!("Date : {}", system_time)).ok();
+                MessageNotation::info_noheader(
+                    &mut stdout,
+                    format!("Message : Unsigned Image (DLL)"),
+                )
+                .ok();
+                MessageNotation::info_noheader(
+                    &mut stdout,
+                    format!("Result  : Loaded by: {}", _image),
+                )
+                .ok();
+                MessageNotation::info_noheader(&mut stdout, format!("Command : {}", _command_line))
+                    .ok();
             }
         };
     }

--- a/src/detections/system.rs
+++ b/src/detections/system.rs
@@ -1,3 +1,4 @@
+use crate::detections::print::MessageNotation;
 use crate::detections::utils;
 use crate::models::event;
 use std::collections::HashMap;
@@ -37,11 +38,18 @@ impl System {
         let commandline = &event_data.get("ImagePath").unwrap_or(&default);
         let text = utils::check_regex(&servicename, 1);
         if !text.is_empty() {
-            println!("Date    : {}", system_time);
-            println!("Message : New Service Created");
-            println!("Command : {}", commandline);
-            println!("Results : Service name: {}", servicename);
-            println!("Results : {}", text);
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            MessageNotation::info_noheader(&mut stdout, format!("Date    : {}", system_time)).ok();
+            MessageNotation::info_noheader(&mut stdout, format!("Message : New Service Created"))
+                .ok();
+            MessageNotation::info_noheader(&mut stdout, format!("Command : {}", commandline)).ok();
+            MessageNotation::info_noheader(
+                &mut stdout,
+                format!("Results : Service name: {}", servicename),
+            )
+            .ok();
+            MessageNotation::info_noheader(&mut stdout, format!("Results : {}", text)).ok();
         }
         if !commandline.is_empty() {
             utils::check_command(7045, &commandline, 1000, 0, &servicename, &"", &system_time);
@@ -60,11 +68,35 @@ impl System {
 
         let default = String::from("");
         let servicename = &event_data.get("param1").unwrap_or(&default);
-        println!("Date    : {}", system_time);
-        println!("Message : Interactive service warning");
-        println!("Results : Service name: {}", servicename);
-        println!("Results : Malware (and some third party software) trigger this warning");
-        println!("{}", utils::check_regex(&servicename, 1));
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        MessageNotation::info_noheader(&mut stdout, format!("Date    : {}", system_time)).ok();
+        MessageNotation::info_noheader(
+            &mut stdout,
+            format!("Message : Interactive service warning"),
+        )
+        .ok();
+        MessageNotation::info_noheader(
+            &mut stdout,
+            format!("Results : Service name: {}", servicename),
+        )
+        .ok();
+        MessageNotation::info_noheader(
+            &mut stdout,
+            format!("Results : Service name: {}", servicename),
+        )
+        .ok();
+
+        MessageNotation::info_noheader(
+            &mut stdout,
+            format!("Results : Malware (and some third party software) trigger this warning"),
+        )
+        .ok();
+        MessageNotation::info_noheader(
+            &mut stdout,
+            format!("{}", utils::check_regex(&servicename, 1)),
+        )
+        .ok();
     }
 
     fn suspicious_service_name(
@@ -81,10 +113,20 @@ impl System {
         let servicename = &event_data.get("param1").unwrap_or(&default);
         let text = utils::check_regex(&servicename, 1);
         if !text.is_empty() {
-            println!("Date    : {}", system_time);
-            println!("Message : Suspicious Service Name");
-            println!("Results : Service name: {}", servicename);
-            println!("Results : {}", text);
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            MessageNotation::info_noheader(&mut stdout, format!("Date    : {}", system_time)).ok();
+            MessageNotation::info_noheader(
+                &mut stdout,
+                format!("Message : Suspicious Service Name"),
+            )
+            .ok();
+            MessageNotation::info_noheader(
+                &mut stdout,
+                format!("Results : Service name: {}", servicename),
+            )
+            .ok();
+            MessageNotation::info_noheader(&mut stdout, format!("Results : {}", text)).ok();
         }
     }
 
@@ -92,10 +134,15 @@ impl System {
         if event_id != "104" {
             return;
         }
-
-        println!("Date : {}", system_time);
-        println!("Message : System Log Clear");
-        println!("Results : The System log was cleared.");
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        MessageNotation::info_noheader(&mut stdout, format!("Date : {}", system_time)).ok();
+        MessageNotation::info_noheader(&mut stdout, format!("Message : System Log Clear")).ok();
+        MessageNotation::info_noheader(
+            &mut stdout,
+            format!("Results : The System log was cleared."),
+        )
+        .ok();
     }
 
     fn windows_event_log(
@@ -110,19 +157,36 @@ impl System {
 
         if let Some(_param1) = event_data.get("param1") {
             if _param1 == "Windows Event Log" {
-                println!("Date : {}", system_time);
-                println!("Service name : {}", _param1);
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::info_noheader(&mut stdout, format!("Date : {}", system_time)).ok();
+                MessageNotation::info_noheader(&mut stdout, format!("Service name : {}", _param1))
+                    .ok();
                 if let Some(_param2) = event_data.get("param2") {
                     if _param2 == "disabled" {
-                        println!("Message : Event Log Service Stopped");
-                        println!(
-                            "Results : Selective event log manipulation may follow this event."
-                        );
+                        MessageNotation::info_noheader(
+                            &mut stdout,
+                            format!("Message : Event Log Service Stopped"),
+                        )
+                        .ok();
+                        MessageNotation::info_noheader(
+                            &mut stdout,
+                            format!(
+                                "Results : Selective event log manipulation may follow this event."
+                            ),
+                        )
+                        .ok();
                     } else if _param2 == "auto start" {
-                        println!("Message : Event Log Service Started");
-                        println!(
-                            "Results : Selective event log manipulation may precede this event."
-                        );
+                        MessageNotation::info_noheader(
+                            &mut stdout,
+                            format!("Message : Event Log Service Started"),
+                        )
+                        .ok();
+                        MessageNotation::info_noheader(
+                            &mut stdout,
+                            format!("Results : Selective event log manipulation may precede this event."),
+                        )
+                        .ok();
                     }
                 }
             }

--- a/src/detections/utils.rs
+++ b/src/detections/utils.rs
@@ -3,6 +3,7 @@ extern crate csv;
 extern crate regex;
 
 use crate::detections::configs;
+use crate::detections::print::MessageNotation;
 use flate2::read::GzDecoder;
 use regex::Regex;
 use std::io::prelude::*;
@@ -65,11 +66,20 @@ pub fn check_command(
             {
                 let mut d = GzDecoder::new(decoded.as_slice());
                 let mut uncompressed = String::new();
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
                 d.read_to_string(&mut uncompressed).unwrap();
-                println!("Decoded : {}", uncompressed);
+                MessageNotation::info_noheader(&mut stdout, format!("Decoded : {}", uncompressed))
+                    .ok();
                 text.push_str("Base64-encoded and compressed function\n");
             } else {
-                println!("Decoded : {}", str::from_utf8(decoded.as_slice()).unwrap());
+                let stdout = std::io::stdout();
+                let mut stdout = stdout.lock();
+                MessageNotation::info_noheader(
+                    &mut stdout,
+                    format!("Decoded : {}", str::from_utf8(decoded.as_slice()).unwrap()),
+                )
+                .ok();
                 text.push_str("Base64-encoded function\n");
                 text.push_str(&check_obfu(str::from_utf8(decoded.as_slice()).unwrap()));
                 text.push_str(&check_regex(str::from_utf8(decoded.as_slice()).unwrap(), 0));
@@ -77,16 +87,30 @@ pub fn check_command(
         }
     }
     if !text.is_empty() {
-        println!("Date : {}", system_time);
-        println!("EventID : {}", event_id);
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        MessageNotation::info_noheader(&mut stdout, format!("Date : {}", system_time)).ok();
+        MessageNotation::info_noheader(&mut stdout, format!("EventID : {}", event_id)).ok();
         if servicecmd != 0 {
-            println!("Message : Suspicious Service Command");
-            println!("Results : Service name: {}\n", servicename);
+            MessageNotation::info_noheader(
+                &mut stdout,
+                format!("Message : Suspicious Service Command"),
+            )
+            .ok();
+            MessageNotation::info_noheader(
+                &mut stdout,
+                format!("Results : Service name: {}\n", servicename),
+            )
+            .ok();
         } else {
-            println!("Message : Suspicious Command Line");
+            MessageNotation::info_noheader(
+                &mut stdout,
+                format!("Message : Suspicious Command Line"),
+            )
+            .ok();
         }
-        println!("command : {}", commandline);
-        println!("result : {}", text);
+        MessageNotation::info_noheader(&mut stdout, format!("command : {}", commandline)).ok();
+        MessageNotation::info_noheader(&mut stdout, format!("result : {}", text)).ok();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate serde;
 use evtx::EvtxParser;
 use rusty_blue::detections::configs;
 use rusty_blue::detections::detection;
+use rusty_blue::detections::print::MessageNotation;
 use std::{fs, path::PathBuf, process};
 
 fn main() {
@@ -17,8 +18,16 @@ fn main() {
 
 fn print_credits() {
     match fs::read_to_string("./credits.txt") {
-        Ok(contents) => println!("{}", contents),
-        Err(err) => println!("Error : credits.txt not found , {}", err),
+        Ok(contents) => {
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            MessageNotation::info_noheader(&mut stdout, format!("{}", contents)).ok();
+        }
+        Err(err) => {
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            MessageNotation::alert(&mut stdout, format!("credits.txt not found , {}", err)).ok();
+        }
     }
 }
 
@@ -27,7 +36,9 @@ fn parse_file(filepath: &str) {
     let parser = match EvtxParser::from_path(fp) {
         Ok(pointer) => pointer,
         Err(e) => {
-            eprintln!("{}", e);
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            MessageNotation::alert(&mut stdout, format!("{}", e)).ok();
             process::exit(1);
         }
     };


### PR DESCRIPTION
closed #9 

MessageNotation構造体を作成し、以下3つのメッセージ形式に合わせて出力をsるうように各関数を作成しました。
1. ERROR用のヘッダがついているもの(エラー系統に利用)
2. ヘッダが何もついていない出力(既存のデータ出力を行っている個所に利用)
3. WARNヘッダがついているもの(メッセージ内にWARNINGが明記されているものを対象)